### PR TITLE
Remove the check if there are mapping aware services defined

### DIFF
--- a/src/DependencyInjection/JsonRpcHttpServerExtension.php
+++ b/src/DependencyInjection/JsonRpcHttpServerExtension.php
@@ -153,10 +153,6 @@ class JsonRpcHttpServerExtension implements ExtensionInterface, CompilerPassInte
     {
         $mappingAwareServiceDefinitionList = $this->findAndValidateMappingAwareDefinitionList($container);
 
-        if (0 === count($mappingAwareServiceDefinitionList)) {
-            return;
-        }
-
         $jsonRpcMethodDefinitionList = (new JsonRpcMethodDefinitionHelper())
             ->findAndValidateJsonRpcMethodDefinition($container);
 


### PR DESCRIPTION
Remove the check if there are mapping aware services defined as the resolver argument still needs to be set on line 169 if no mapping aware services are defined.