### PR TITLE
Symfony/http-kernel 5.1 updates. update deprecated references of controllers

### DIFF
--- a/src/Resources/config/routing/endpoint.xml
+++ b/src/Resources/config/routing/endpoint.xml
@@ -9,13 +9,13 @@
         path="%json_rpc_http_server.http_endpoint_path%"
         methods="POST"
     >
-        <default key="_controller">json_rpc_http_server.endpoint:httpPost</default>
+        <default key="_controller">json_rpc_http_server.endpoint::httpPost</default>
     </route>
     <route
         id="json_rpc_http_server_endpoint_options"
         path="%json_rpc_http_server.http_endpoint_path%"
         methods="OPTIONS"
     >
-        <default key="_controller">json_rpc_http_server.endpoint:httpOptions</default>
+        <default key="_controller">json_rpc_http_server.endpoint::httpOptions</default>
     </route>
 </routes>


### PR DESCRIPTION
update deprecated references of controllers with a single colon to double colon because of User Deprecated: Since symfony/http-kernel 5.1: Referencing controllers with a single colon is deprecated. Use "json_rpc_http_server.endpoint::httpPost" instead.