### PR TITLE
Add `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Ignore all test and documentation for archive
+/.github            export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.scrutinizer.yml   export-ignore
+/.travis.yml        export-ignore
+/behat.yml          export-ignore
+/phpunit.xml.dist   export-ignore
+/phpcs.xml.dist     export-ignore
+/CODE_OF_CONDUCT.md export-ignore
+/CONTRIBUTING.md    export-ignore
+/Makefile           export-ignore
+/tests              export-ignore
+/features           export-ignore
+/docs               export-ignore

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -106,8 +106,9 @@ jobs:
         run: make test-unit && make test-functional
 
       # Upload to codacy first as codecov action always remove coverage files despite move_coverage_to_trash at false
+      # And only if it's not a PR from a fork => Can't work as codacy secret is not accessible in that context
       - name: Upload coverages to Codacy
-        if: ${{ env.COVERAGE_TYPE == 'xdebug' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'yoanm/symfony-jsonrpc-http-server' && env.COVERAGE_TYPE == 'xdebug' }}
         run: ${{ env.CODACY_BIN }} report -r build/coverage-phpunit/unit.clover -r build/coverage-behat/clover.xml -r build/coverage-phpunit/functional.clover -t ${{ secrets.CODACY_PROJECT_TOKEN }} --partial
 
       # See the reports at https://codecov.io/gh/yoanm/symfony-jsonrpc-http-server
@@ -172,6 +173,7 @@ jobs:
   finalize-codacy-coverage-report:
     runs-on: ubuntu-latest
     name: Finalize Codacy coverage report
+    if: ${{ github.event.pull_request.head.repo.full_name == 'yoanm/symfony-jsonrpc-http-server' }}
     needs: [ tests ]
     steps:
       - name: Setup cache
@@ -199,7 +201,7 @@ jobs:
     env:
       COMPOSER_OPTIONS: '--optimize-autoloader --ignore-platform-req=php+'
     continue-on-error: true
-    needs: [ static-checks, finalize-codacy-coverage-report ]
+    needs: [ static-checks, tests ]
     strategy:
       fail-fast: false
       max-parallel: 4


### PR DESCRIPTION
Add `.gitattributes` with `export-ignore` directive.
This allows to minimize the size of the future release tags.